### PR TITLE
Basic rebus support

### DIFF
--- a/exet-autofill.js
+++ b/exet-autofill.js
@@ -1095,10 +1095,6 @@ class ExetAutofill {
 
   startstop() {
     if (!this.running) {
-      if (exet.puz.hasRebusCells) {
-        alert('Autofill is not supported for rebus puzzles.');
-        return;
-      }
       if (exet.puz.numCellsToFill == exet.puz.numCellsFilled) {
         alert('The grid is already full');
         return;

--- a/exet-autofill.js
+++ b/exet-autofill.js
@@ -1095,6 +1095,10 @@ class ExetAutofill {
 
   startstop() {
     if (!this.running) {
+      if (exet.puz.hasRebusCells) {
+        alert('Autofill is not supported for rebus puzzles.');
+        return;
+      }
       if (exet.puz.numCellsToFill == exet.puz.numCellsFilled) {
         alert('The grid is already full');
         return;

--- a/exet.css
+++ b/exet.css
@@ -105,6 +105,28 @@ body {
   color: red;
   cursor: wait;
 }
+.xet-iframe-loading::after {
+  display: inline-block;
+  width: 3ch;
+  text-align: left;
+  vertical-align: bottom;
+  content: '';
+  animation: xet-loading-ellipsis 1.2s infinite;
+}
+@keyframes xet-loading-ellipsis {
+  0%, 20% {
+    content: '';
+  }
+  40% {
+    content: '.';
+  }
+  60% {
+    content: '..';
+  }
+  80%, 100% {
+    content: '...';
+  }
+}
 .xet-td {
   vertical-align: top;
 }

--- a/exet.js
+++ b/exet.js
@@ -380,10 +380,6 @@ Exet.prototype.setPuzzle = function(puz) {
     alert('Nodir clues not yet supported');
     return;
   }
-  if (puz.hasRebusCells) {
-    alert('Rebus cells are not supported');
-    return;
-  }
   if (puz.offNumClueIndices.length > 0) {
     alert('Non-numeric clues not yet supported');
     return;
@@ -421,9 +417,9 @@ Exet.prototype.setPuzzle = function(puz) {
         gridFillChanges = true;
       }
       if (gridCell.solution != '?' &&
-          !exetLexicon.letterSet[gridCell.solution]) {
+          !this.isValidGridCellSolution(puz, gridCell.solution)) {
         alert('Entry ' + gridCell.solution + ' in grid[' + i + '][' + j +
-              '] is not present in the lexicon. Marking the cell as unfilled.');
+              '] is not valid. Marking the cell as unfilled.');
         gridCell.solution = '?';
         gridFillChanges = true;
       }
@@ -762,6 +758,113 @@ Exet.prototype.setPuzzle = function(puz) {
 
   this.updateSweepInd();
   this.reposition();
+  this.syncRebusCheckbox();
+}
+
+Exet.prototype.isValidGridCellSolution = function(puz, solution) {
+  if (solution == '?' || solution == '0') {
+    return true;
+  }
+  if (puz.hasRebusCells) {
+    return puz.isValidStateChar(solution);
+  }
+  return exetLexicon.letterSet[solution];
+}
+
+/** True if any cell in this light contains a multi-letter rebus entry. */
+Exet.prototype.lightHasRebusContent = function(ci) {
+  if (!this.puz || !this.puz.hasRebusCells || !ci) {
+    return false;
+  }
+  const cells = this.puz.getAllCells(ci);
+  for (const cell of cells) {
+    const gridCell = this.puz.grid[cell[0]][cell[1]];
+    const letter = gridCell.currLetter;
+    if (letter != '?' && letter != '0' && letter.length > 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Exet.prototype.syncRebusCheckbox = function() {
+  const cb = document.getElementById('xet-rebus-cells');
+  if (!cb) {
+    return;
+  }
+  cb.checked = this.puz && this.puz.hasRebusCells;
+  cb.disabled = this.puz && this.puz.langMaxCharCodes > 1;
+}
+
+Exet.prototype.syncRebusOptionInOtherSec = function(enabled) {
+  const lines = [];
+  let rebusHandled = false;
+  for (const line of this.exolveOtherSec.split('\n')) {
+    const t = line.trim();
+    if (!t.startsWith('exolve-option:')) {
+      if (t) {
+        lines.push(line);
+      }
+      continue;
+    }
+    let opts = t.substring('exolve-option:'.length).trim().split(/\s+/);
+    opts = opts.filter(o => o != 'rebus-cells');
+    if (enabled && !rebusHandled) {
+      opts.unshift('rebus-cells');
+      rebusHandled = true;
+    }
+    if (opts.length > 0) {
+      lines.push('  exolve-option: ' + opts.join(' '));
+    }
+  }
+  if (enabled && !rebusHandled) {
+    lines.unshift('  exolve-option: rebus-cells');
+  }
+  this.exolveOtherSec = lines.join('\n').trim();
+}
+
+Exet.prototype.setRebusCells = function(enabled) {
+  if (!this.puz) {
+    return;
+  }
+  if (enabled) {
+    if (this.puz.langMaxCharCodes > 1) {
+      alert('Rebus cells cannot be used when the language has max-char-codes > 1.');
+      this.syncRebusCheckbox();
+      return;
+    }
+    if (this.puz.hasDgmlessCells) {
+      alert('Rebus cells cannot be used with diagramless cells.');
+      this.syncRebusCheckbox();
+      return;
+    }
+    this.puz.hasRebusCells = true;
+    this.puz.multiLetter = true;
+  } else {
+    for (let i = 0; i < this.puz.gridHeight; i++) {
+      for (let j = 0; j < this.puz.gridWidth; j++) {
+        const gridCell = this.puz.grid[i][j];
+        if (!gridCell.isLight) {
+          continue;
+        }
+        const letter = gridCell.currLetter;
+        if (letter != '?' && letter != '0' && letter.length > 1) {
+          alert('Cannot turn off rebus cells while some cells contain ' +
+                'multiple letters.');
+          this.syncRebusCheckbox();
+          return;
+        }
+      }
+    }
+    this.puz.hasRebusCells = false;
+    this.puz.multiLetter = (this.puz.langMaxCharCodes > 1);
+  }
+  if (this.puz.adjustRebusFonts) {
+    this.puz.adjustRebusFonts();
+  }
+  this.syncRebusOptionInOtherSec(enabled);
+  this.autofill.reset('Aborted');
+  this.updatePuzzle(exetRevManager.REV_OPTIONS_CHANGE);
 }
 
 Exet.prototype.populateSpellingsRegionMenu = function() {
@@ -1129,6 +1232,15 @@ Exet.prototype.makeExetTab = function() {
                   value="asymmetric" type="checkbox">
                 </input>
                 <i>Allow asymmetry</i>
+              </div>
+              <div style="padding:10px"
+                  title="Allow multiple letters in a cell (Shift or double-click ` +
+                  `to enter). Autofill is disabled; grid-fill is disabled only ` +
+                  `for entries that contain a rebus cell.">
+                <input id="xet-rebus-cells" name="xet-rebus-cells"
+                  value="rebus-cells" type="checkbox">
+                </input>
+                <i>Use rebus cells</i>
               </div>
             </div>
           </div>
@@ -1652,6 +1764,11 @@ Exet.prototype.makeExetTab = function() {
   asymOKButton.addEventListener('change', e => {
     exet.asymOK = asymOKButton.checked ? true : false;
     exetRevManager.throttledSaveRev(exetRevManager.REV_OPTIONS_CHANGE);
+  });
+
+  const rebusCellsButton = document.getElementById("xet-rebus-cells")
+  rebusCellsButton.addEventListener('change', e => {
+    exet.setRebusCells(rebusCellsButton.checked);
   });
 
   const preamble = document.getElementById("xet-preamble")
@@ -6161,6 +6278,7 @@ Exet.prototype.getGrid = function(solved=true) {
   if (!this.puz) {
     return '';
   }
+  const useRebus = this.puz.hasRebusCells;
   const ENTRY_WIDTH = 3 + this.puz.langMaxCharCodes;
   let grid = '';
   for (let i = 0; i < this.puz.gridHeight; i++) {
@@ -6169,17 +6287,29 @@ Exet.prototype.getGrid = function(solved=true) {
       let gridCell = this.puz.grid[i][j]
       let entry = '.';
       if (gridCell.isLight) {
-        entry = (gridCell.currLetter != '0' ?
+        let letter = (gridCell.currLetter != '0' ?
                ((solved || gridCell.prefill) ?
                      gridCell.currLetter : '0') : '?');
+        if (letter != '?' && letter != '0') {
+          entry = this.puz.stateToDisplayChar(letter);
+        } else {
+          entry = letter;
+        }
         if (gridCell.hasCircle) entry += '@';
         if (gridCell.prefill) entry += '!';
         entry += (gridCell.hasBarAfter && gridCell.hasBarUnder ?
                               '+' : (gridCell.hasBarAfter ?
                               '|' : (gridCell.hasBarUnder ? '_' : '')));
       }
-      while (entry.length < ENTRY_WIDTH) entry += ' ';
-      gridRow += entry;
+      if (useRebus) {
+        gridRow += entry;
+        if (j < this.puz.gridWidth - 1) {
+          gridRow += ' ';
+        }
+      } else {
+        while (entry.length < ENTRY_WIDTH) entry += ' ';
+        gridRow += entry;
+      }
     }
     grid = grid + '\n' + gridRow;
   }
@@ -6424,6 +6554,9 @@ Exet.prototype.refineLightChoices = function(fillState, limit=0) {
     const theClue = fillState.clues[ci];
     if (theClue.parentClueIndex ||
         !theClue.solution || theClue.solution.indexOf('?') < 0) {
+      continue;
+    }
+    if (this.lightHasRebusContent(ci)) {
       continue;
     }
     const cells = this.puz.getAllCells(ci);
@@ -6958,6 +7091,9 @@ Exet.prototype.fillLight = function(idx, ci='', revType=null) {
   if (!ci) {
     return;
   }
+  if (this.lightHasRebusContent(ci)) {
+    return;
+  }
   let solution = exetLexicon.getLex(idx);
   let theClue = this.puz.clues[ci];
   let cells = this.puz.getAllCells(ci);
@@ -7280,6 +7416,12 @@ Exet.prototype.choiceDisplayHTML = function(choice) {
 Exet.prototype.updateFillChoices = function() {
   let ci = this.currClueIndex();
   if (!ci) {
+    return;
+  }
+  if (this.lightHasRebusContent(ci)) {
+    this.lChoices.innerHTML =
+        '<tr><td><i>Grid-fill disabled for this entry (contains a rebus cell)</i></td></tr>';
+    this.lRejects.innerHTML = '';
     return;
   }
   const gridClue = this.puz.clues[ci];

--- a/exet.js
+++ b/exet.js
@@ -827,7 +827,8 @@ Exet.prototype.walkLightKey = function(cells, grid, key, visitor) {
     const gridCell = grid[cells[i][0]][cells[i][1]];
     const fixed = this.cellFixedContent(gridCell);
     if (fixed.length > 1) {
-      if (key.substr(ki, fixed.length) != fixed) {
+      const slice = key.slice(ki, ki + fixed.length).join('');
+      if (slice != fixed) {
         return false;
       }
       ki += fixed.length;

--- a/exet.js
+++ b/exet.js
@@ -2445,7 +2445,7 @@ Exet.prototype.loadIframe = function(iframe, url, urlElt) {
   urlElt.innerText = trimmedUrl;
   urlElt.insertAdjacentHTML(
       'beforeend',
-      ' <span class="xet-iframe-loading">Loading...</span>');
+      ' <span class="xet-iframe-loading">Loading</span>');
   urlElt.href = url;
   /* Nutrimatic uses huge score-based fonts; shrink those iframes via CSS.
    * Cross-origin pages can't be rewritten into a bullet list without a proxy. */

--- a/exet.js
+++ b/exet.js
@@ -778,13 +778,82 @@ Exet.prototype.lightHasRebusContent = function(ci) {
   }
   const cells = this.puz.getAllCells(ci);
   for (const cell of cells) {
-    const gridCell = this.puz.grid[cell[0]][cell[1]];
-    const letter = gridCell.currLetter;
-    if (letter != '?' && letter != '0' && letter.length > 1) {
+    if (this.cellHasRebusContent(this.puz.grid[cell[0]][cell[1]])) {
       return true;
     }
   }
   return false;
+}
+
+Exet.prototype.cellHasRebusContent = function(gridCell) {
+  if (!gridCell || !this.puz || !this.puz.hasRebusCells) {
+    return false;
+  }
+  const fixed = this.cellFixedContent(gridCell);
+  return fixed.length > 1;
+}
+
+Exet.prototype.cellFixedContent = function(gridCell) {
+  if (gridCell.solution != '?' && gridCell.solution != '0') {
+    return gridCell.solution;
+  }
+  if (gridCell.currLetter != '?' && gridCell.currLetter != '0') {
+    return gridCell.currLetter;
+  }
+  return '';
+}
+
+/**
+ * Count dictionary letter-slots in a light: one per normal cell, but
+ * rebus cells consume as many letters as their fixed content.
+ */
+Exet.prototype.lightLetterSlotCount = function(cells, grid) {
+  let count = 0;
+  for (const cell of cells) {
+    const fixed = this.cellFixedContent(grid[cell[0]][cell[1]]);
+    count += (fixed.length > 1) ? fixed.length : 1;
+  }
+  return count;
+}
+
+/**
+ * Walk a lexkey alongside light cells. Fixed rebus cells consume multiple
+ * key letters; other cells consume one each. The visitor receives
+ * (cellIndex, gridCell, letter) for each single-letter cell.
+ */
+Exet.prototype.walkLightKey = function(cells, grid, key, visitor) {
+  let ki = 0;
+  for (let i = 0; i < cells.length; i++) {
+    const gridCell = grid[cells[i][0]][cells[i][1]];
+    const fixed = this.cellFixedContent(gridCell);
+    if (fixed.length > 1) {
+      if (key.substr(ki, fixed.length) != fixed) {
+        return false;
+      }
+      ki += fixed.length;
+      continue;
+    }
+    if (ki >= key.length) {
+      return false;
+    }
+    if (!visitor(i, gridCell, key[ki])) {
+      return false;
+    }
+    ki++;
+  }
+  return ki == key.length;
+}
+
+Exet.prototype.applySolutionToLight = function(cells, key) {
+  let changed = false;
+  const ok = this.walkLightKey(cells, this.puz.grid, key, (i, gridCell, letter) => {
+    if (gridCell.currLetter != letter || gridCell.solution != letter) {
+      this.puz.setCellLetter(gridCell, letter);
+      changed = true;
+    }
+    return true;
+  });
+  return ok && changed;
 }
 
 Exet.prototype.syncRebusCheckbox = function() {
@@ -1235,8 +1304,8 @@ Exet.prototype.makeExetTab = function() {
               </div>
               <div style="padding:10px"
                   title="Allow multiple letters in a cell (Shift or double-click ` +
-                  `to enter). Autofill is disabled; grid-fill is disabled only ` +
-                  `for entries that contain a rebus cell.">
+                  `to enter). Autofill and grid-fill only use single letters and ` +
+                  `leave existing rebus cells unchanged.">
                 <input id="xet-rebus-cells" name="xet-rebus-cells"
                   value="rebus-cells" type="checkbox">
                 </input>
@@ -6556,9 +6625,6 @@ Exet.prototype.refineLightChoices = function(fillState, limit=0) {
         !theClue.solution || theClue.solution.indexOf('?') < 0) {
       continue;
     }
-    if (this.lightHasRebusContent(ci)) {
-      continue;
-    }
     const cells = this.puz.getAllCells(ci);
     const toConsider = (limit <= 0) ? theClue.lChoices.length :
         Math.min(limit, theClue.lChoices.length);
@@ -6576,21 +6642,25 @@ Exet.prototype.refineLightChoices = function(fillState, limit=0) {
       }
       const key = exetLexicon.lexkey(exetLexicon.getLex(lchoice));
       if (lchoice < 0) key.reverse();
-      let viable = true;
-      for (let i = 0; i < key.length; i++) {
-        const cell = cells[i];
-        console.assert(cell && cell.length == 2, ci, i);
-        const gridCell = fillState.grid[cell[0]][cell[1]];
-        if (gridCell.solution == '?' && !gridCell.cChoices[key[i]]) {
-          viable = false;
-          break;
+      let viable = this.walkLightKey(cells, fillState.grid, key,
+          (i, gridCell, letter) => {
+        if (gridCell.solution != '?' && gridCell.solution != letter) {
+          return false;
         }
-      }
+        if (gridCell.solution == '?' && !gridCell.cChoices[letter]) {
+          return false;
+        }
+        return true;
+      });
       if (viable) {
         theClue.lChoices.push(lchoice);
-        for (let i = 0; i < key.length; i++) {
-          cellChoiceSets[i][key[i]] = true;
-        }
+        this.walkLightKey(cells, fillState.grid, key,
+            (i, gridCell, letter) => {
+          if (gridCell.solution == '?') {
+            cellChoiceSets[i][letter] = true;
+          }
+          return true;
+        });
       } else {
         this.noteNonViableChoice(theClue, lchoice);
         changes++;
@@ -6779,10 +6849,11 @@ Exet.prototype.someClueTurnsNonViable = function(tempFillState) {
         let lchoice = tempClue.lChoices[i];
         let key = exetLexicon.lexkey(exetLexicon.getLex(lchoice));
         if (lchoice < 0) key.reverse();
-        console.assert(key.length = cells.length, key.length, cells.length);
-        for (let k = 0; k < key.length; k++) {
-          cellChoiceSets[k][key[k]] = true;
-        }
+        this.walkLightKey(cells, tempFillState.grid, key,
+            (k, gridCell, letter) => {
+          cellChoiceSets[k][letter] = true;
+          return true;
+        });
       }
       for (let i = 0; i < cells.length; i++) {
         let cell = cells[i];
@@ -6811,18 +6882,13 @@ Exet.prototype.someClueTurnsNonViable = function(tempFillState) {
         let lchoice = choices[i];
         let key = exetLexicon.lexkey(exetLexicon.getLex(lchoice))
         if (lchoice < 0) key.reverse();
-        let viable = true;
-        for (let j = 0; j < key.length; j++) {
-          let cell = cells[j];
-          let gridCell = tempFillState.grid[cell[0]][cell[1]];
+        let viable = this.walkLightKey(cells, tempFillState.grid, key,
+            (k, gridCell, letter) => {
           if (gridCell.solution != '?') {
-            continue;
+            return gridCell.solution == letter;
           }
-          if (!gridCell.cChoices[key[j]]) {
-            viable = false;
-            break;
-          }
-        }
+          return !!gridCell.cChoices[letter];
+        });
         if (viable) {
           tempClue.lChoices.push(lchoice);
         } else {
@@ -6882,13 +6948,16 @@ Exet.prototype.findDeadendsByClue = function() {
   for (let lchoice of choices) {
     let key = exetLexicon.lexkey(exetLexicon.getLex(lchoice));
     if (lchoice < 0) key.reverse();
-    console.assert(key.length = cells.length, key.length, cells.length);
     let tempFillState = new ExetFillState(this.fillState);
-    for (let i = 0; i < cells.length; i++) {
-      let cell = cells[i];
-      let tempGridCell = tempFillState.grid[cell[0]][cell[1]];
+    if (!this.walkLightKey(cells, tempFillState.grid, key,
+        (i, gridCell, letter) => {
+      const tempGridCell = tempFillState.grid[cells[i][0]][cells[i][1]];
       tempGridCell.cChoices = {};
-      tempGridCell.cChoices[key[i]] = true;
+      tempGridCell.cChoices[letter] = true;
+      return true;
+    })) {
+      this.noteNonViableChoice(theClue, lchoice);
+      continue;
     }
     if (!this.someClueTurnsNonViable(tempFillState)) {
       viableChoices.push(lchoice);
@@ -7091,15 +7160,13 @@ Exet.prototype.fillLight = function(idx, ci='', revType=null) {
   if (!ci) {
     return;
   }
-  if (this.lightHasRebusContent(ci)) {
-    return;
-  }
   let solution = exetLexicon.getLex(idx);
   let theClue = this.puz.clues[ci];
   let cells = this.puz.getAllCells(ci);
+  const key = exetLexicon.lexkey(solution);
   if (!theClue || !solution ||
       theClue.parentClueIndex ||
-      exetLexicon.lexkey(solution).length != cells.length) {
+      key.length != this.lightLetterSlotCount(cells, this.puz.grid)) {
     return;
   }
   // All checks passed!
@@ -7121,38 +7188,47 @@ Exet.prototype.fillLight = function(idx, ci='', revType=null) {
     theClue.solution = solution;
     changed = true;
   }
-  let enumStr = '';
-  let enumPart = 0;
-  let solIndex = 0;
-  const solParts = exetLexicon.partsOf(solution);
-  for (let i = 0; i < solParts.length; i++) {
-    let c = solParts[i];
-    if (enumPart > 0 && (c == ' ' || c == '-' || c == '\'')) {
-      enumStr += ('' + enumPart + (c == ' ' ? ',' : c));
-      enumPart = 0;
-    }
-    if (exetLexicon.letterSet[c]) {
-      enumPart++;
-      let cell = cells[solIndex++];
-      let gridCell = this.puz.grid[cell[0]][cell[1]];
-      if (gridCell.currLetter != c || gridCell.solution != c) {
-        this.puz.setCellLetter(gridCell, c);
-        changed = true;
+  const fillKey = exetLexicon.lexkey(solution);
+  if (fillKey.length != this.lightLetterSlotCount(cells, this.puz.grid)) {
+    return;
+  }
+  if (this.applySolutionToLight(cells, fillKey)) {
+    changed = true;
+  } else if (!this.walkLightKey(cells, this.puz.grid, fillKey,
+      (i, gridCell, letter) => {
+    return gridCell.currLetter == letter && gridCell.solution == letter;
+  })) {
+    return;
+  }
+  if (!this.lightHasRebusContent(ci)) {
+    let enumStr = '';
+    let enumPart = 0;
+    let solIndex = 0;
+    const solParts = exetLexicon.partsOf(solution);
+    for (let i = 0; i < solParts.length; i++) {
+      let c = solParts[i];
+      if (enumPart > 0 && (c == ' ' || c == '-' || c == '\'')) {
+        enumStr += ('' + enumPart + (c == ' ' ? ',' : c));
+        enumPart = 0;
+      }
+      if (exetLexicon.letterSet[c]) {
+        enumPart++;
+        solIndex++;
       }
     }
-  }
-  if (enumPart > 0) {
-    enumStr = enumStr + enumPart;
-  }
-  if (enumStr) {
-    enumStr = '(' + enumStr + ')';
-  }
-  if (this.requireEnums) {
-    const parsedEnum = this.puz.parseEnum(theClue.clue);
-    if (parsedEnum.enumStr != enumStr) {
-      theClue.clue = theClue.clue.substr(0, parsedEnum.afterClue).trim() +
-        ' ' + enumStr;
-      changed = true;
+    if (enumPart > 0) {
+      enumStr = enumStr + enumPart;
+    }
+    if (enumStr) {
+      enumStr = '(' + enumStr + ')';
+    }
+    if (this.requireEnums) {
+      const parsedEnum = this.puz.parseEnum(theClue.clue);
+      if (parsedEnum.enumStr != enumStr) {
+        theClue.clue = theClue.clue.substr(0, parsedEnum.afterClue).trim() +
+          ' ' + enumStr;
+        changed = true;
+      }
     }
   }
   if (changed && updateIfChanged) {
@@ -7416,12 +7492,6 @@ Exet.prototype.choiceDisplayHTML = function(choice) {
 Exet.prototype.updateFillChoices = function() {
   let ci = this.currClueIndex();
   if (!ci) {
-    return;
-  }
-  if (this.lightHasRebusContent(ci)) {
-    this.lChoices.innerHTML =
-        '<tr><td><i>Grid-fill disabled for this entry (contains a rebus cell)</i></td></tr>';
-    this.lRejects.innerHTML = '';
     return;
   }
   const gridClue = this.puz.clues[ci];


### PR DESCRIPTION
Example:

<img width="186" height="177" alt="image" src="https://github.com/user-attachments/assets/e435896e-fdfc-479d-8069-63be32d4512c" />

Enables primative Rebus support. You must explicitly enable rebuses in your puzzle via the preferences toggle.
Then, you can type in your multi-character cell by holding shift while typing.

Autofill and Gridfill both will observe rebus cells, but will only try to auto-fill with non-rebus cells. (e.g. `[ ][ ][ ][FIRE]` will gridfill to `[G][U][N][FIRE]`, but it is impossible for `[G][U][N][ ]` to fill to `[G][U][N][FIRE]` (It will only fill in single letters like `[G][U][N][K]`. Maybe this is something that could be desired in the future, but for a v1 it seems a reasonable limitation and it would also explode possible fills, and in my opinion, possible devalue the intent of using rebuses?